### PR TITLE
Fix parameter variable name with Navigo.

### DIFF
--- a/docs/Wk3Mod3.md
+++ b/docs/Wk3Mod3.md
@@ -245,7 +245,7 @@ You should see `hello home page!` whenever you visit the landing page of your ap
 
 ```javascript
 router
-  .on(":path", params => console.log(params.page))
+  .on(":page", params => console.log(params.page))
   .on("/", () => console.log("hello home page!"))
   .resolve();
 ```


### PR DESCRIPTION
The parameters names are inconsistent. It uses `:path` and then tries to access `page` property.